### PR TITLE
remove reviewers from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     open-pull-requests-limit: 10
     assignees:
       - "davidlienhard"
-    reviewers:
-      - "davidlienhard"
     labels:
       - "enhancement"
       - "dependencies"
@@ -19,8 +17,6 @@ updates:
     schedule:
       interval: "daily"
     assignees:
-      - "davidlienhard"
-    reviewers:
       - "davidlienhard"
     labels:
       - "enhancement"


### PR DESCRIPTION
do not require a review for dependencies